### PR TITLE
Append/prepend options and utilize event triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-suggestor.js
-============
+a better suggestor.js
+=====================
 
 **suggestor.js** is a suggestions-providing / @user mentions / #tagging / autocompletion library.
 
@@ -9,6 +9,8 @@ It's similar to [Mention.js](https://github.com/jakiestfu/Mention.js), but does 
 It's also less hacky, more flexible and supposedly much less buggy.
 
 **View the demo [here](http://devture.com/projects/suggestor.js)**.
+
+This fork adds some advanced features that haven't been merged into master. The gem's creator, for whatever reason, seems to have abandoned the project. See [recent commits](https://github.com/subvertallchris/suggestor.js/commits/master), the code is commented and simple enough to read.
 
 Dependencies
 ------------

--- a/suggestor.js
+++ b/suggestor.js
@@ -84,10 +84,11 @@
 				state = this.textFieldHelper.getState($textField, this.context.settings.startDelimiter),
 				textBefore = state.text.substring(0, state.queryStartPosition),
 				textAfter = state.text.substring(state.queryEndPosition),
-				suggestionValue = (this.context.settings.startDelimiter + suggestionItem[this.context.settings.insertKey]);
+				suggestionValue = (this.context.settings.startDelimiter + suggestionItem[this.context.settings.insertKey]),
+				finalSuggestionValue = this.context.settings.insertPrepend + suggestionValue + this.context.settings.insertAppend;
 
-			this.context.$textField.val(textBefore + suggestionValue + textAfter);
-			$textField[0].selectionStart = $textField[0].selectionEnd = (textBefore + suggestionValue).length;
+			this.context.$textField.val(textBefore + finalSuggestionValue + textAfter);
+			$textField[0].selectionStart = $textField[0].selectionEnd = (textBefore + finalSuggestionValue).length;
 
 			//Restore focus to the text field, if it got lost (due to a suggestions list click)
 			$textField.focus();
@@ -427,6 +428,12 @@
 			//The json key to insert
 			"insertKey": "id",
 
+			//prepend inserted value with this
+			"insertPrepend": '',
+
+			//append inserted value with this
+			"insertAppend": '',
+
 			//Time to wait (in milliseconds) before suggestions are requested.
 			//Useful for rate-limiting the number of requests to the data-source.
 			"bufferringInterval": 0,
@@ -445,6 +452,7 @@
 
 			//A textarea/input suggestion utilizer - see Suggestor.SuggestionsUtilizer
 			"suggestionsUtilizer": new Suggestor.SuggestionsUtilizer(new Suggestor.TextFieldHelper())
+
 		}, options);
 
 		validateSettings(settings);

--- a/suggestor.js
+++ b/suggestor.js
@@ -92,6 +92,9 @@
 
 			//Restore focus to the text field, if it got lost (due to a suggestions list click)
 			$textField.focus();
+
+			//fire utilize event
+			jQuery($textField).trigger('utilize-mention', suggestionItem);
 		}
 	};
 


### PR DESCRIPTION
This does a couple things:

First, it adds prepend and append options. This is useful if you want to have it insert a string wrapped in a certain way. In my case, I'm using some very basic, simple markup, and I want my users wrapped so they appear as "[@username]":

``` javascript
$(this).suggestor({
  startDelimiter: "@",
  insertKey: 'label',
  insertPrepend: '[',
  insertAppend: ']',
  "suggestionsTemplateHtml": "%label%",
  dataSource: dataSource
});
```

The other thing it does is trigger an event, "utilize-mention," when something is selected and inserted into an input field.

``` javascript
#stupid basic example
$('#input-field').on('utilize-mention', function(event, data) {
  console.log(data);
})
```
